### PR TITLE
Content-Disposition setting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    s3_relay (0.0.2)
+    s3_relay (0.0.3)
       coffee-rails
       rails
 
@@ -81,7 +81,7 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     lumberjack (1.0.9)
-    mail (2.6.1)
+    mail (2.6.3)
       mime-types (>= 1.16, < 3)
     metaclass (0.0.4)
     method_source (0.8.2)
@@ -129,12 +129,12 @@ GEM
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     slop (3.6.0)
-    sprockets (2.12.2)
+    sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.2.0)
+    sprockets-rails (2.2.4)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    s3_relay (0.0.3)
+    s3_relay (0.1.0)
       coffee-rails
       rails
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ product_params = params.require(:product)
 <%= s3_relay_field @product, :photo_uploads, multiple: true %>
 ```
 
+* By default the content-disposition on the files stored in the uploads bucket
+will be set to inline.  You can optionally set it to attachment by passing that
+option like so:
+
+```erb
+<%= s3_relay_field @artist, :mp3_uploads, multiple: true, disposition: "attachment" %>
+```
+
 ### Process uploads asynchronously
 
 Use your background job processor of choice to process uploads pending

--- a/app/assets/javascripts/s3_relay.coffee
+++ b/app/assets/javascripts/s3_relay.coffee
@@ -43,6 +43,7 @@ uploadFile = (container, file) ->
       formData = new FormData()
       xhr = new XMLHttpRequest()
       endpoint = data.endpoint
+      disposition = container.data("disposition")
 
       formData.append("AWSAccessKeyID", data.awsaccesskeyid)
       formData.append("x-amz-server-side-encryption", data.x_amz_server_side_encryption)
@@ -52,6 +53,7 @@ uploadFile = (container, file) ->
       formData.append("policy", data.policy)
       formData.append("signature", data.signature)
       formData.append("content-type", file.type)
+      formData.append("content-disposition", "#{disposition}; filename=\"#{fileName}\"")
       formData.append("file", file)
 
       uuid = data.uuid

--- a/app/helpers/s3_relay/uploads_helper.rb
+++ b/app/helpers/s3_relay/uploads_helper.rb
@@ -13,7 +13,8 @@ module S3Relay
           data:  {
             parent_type: parent_type,
             parent_id:   parent.id.to_s,
-            association: association.to_s
+            association: association.to_s,
+            disposition: opts.fetch(:disposition, "inline")
           }
         }
       )

--- a/lib/s3_relay/upload_presigner.rb
+++ b/lib/s3_relay/upload_presigner.rb
@@ -43,6 +43,7 @@ module S3Relay
           { "x-amz-server-side-encryption" => "AES256" },
           { "success_action_status" => "201" },
           ["starts-with", "$content-type", ""],
+          ["starts-with", "$content-disposition", ""],
           ["starts-with", "$key", "#{uuid}/"]
         ]
       }

--- a/lib/s3_relay/version.rb
+++ b/lib/s3_relay/version.rb
@@ -1,3 +1,3 @@
 module S3Relay
-  VERSION = "0.0.3"
+  VERSION = "0.1.0"
 end

--- a/test/controllers/s3_relay/uploads_controller_test.rb
+++ b/test/controllers/s3_relay/uploads_controller_test.rb
@@ -33,7 +33,7 @@ module S3Relay
         data["success_action_status"].must_equal "201"
         data["acl"].must_equal "acl"
         data["endpoint"].must_equal "https://bucket.s3-region.amazonaws.com"
-        data["policy"].length.must_equal 324  # TODO: Improve this
+        data["policy"].length.must_equal 380  # TODO: Improve this
         data["signature"].length.must_equal 28  # TODO: Improve this
         data["uuid"].must_equal uuid
       end

--- a/test/helpers/s3_relay/uploads_helper_test.rb
+++ b/test/helpers/s3_relay/uploads_helper_test.rb
@@ -4,9 +4,25 @@ describe S3Relay::UploadsHelper do
   before { @product = FactoryGirl.create(:product) }
 
   describe "#s3_relay_field" do
-    it do
-      s3_relay_field(@product, :photo_uploads, multiple: true)
-        .must_equal %Q{<div class="s3r-container" data-association="photo_uploads" data-parent-id="#{@product.id}" data-parent-type="product"><input class="s3r-field" id="file" multiple="multiple" name="file" type="file" /><table class="s3r-upload-list"></table></div>}
+    describe "without options" do
+      it do
+        s3_relay_field(@product, :photo_uploads)
+          .must_equal %Q{<div class="s3r-container" data-association="photo_uploads" data-disposition=\"inline\" data-parent-id="#{@product.id}" data-parent-type="product"><input class="s3r-field" id="file" name="file" type="file" /><table class="s3r-upload-list"></table></div>}
+      end
+    end
+
+    describe "with multiple: true" do
+      it do
+        s3_relay_field(@product, :photo_uploads, multiple: true)
+          .must_equal %Q{<div class="s3r-container" data-association="photo_uploads" data-disposition=\"inline\" data-parent-id="#{@product.id}" data-parent-type="product"><input class="s3r-field" id="file" multiple="multiple" name="file" type="file" /><table class="s3r-upload-list"></table></div>}
+      end
+    end
+
+    describe "with disposition: attachment" do
+      it do
+        s3_relay_field(@product, :photo_uploads, disposition: :attachment)
+          .must_equal %Q{<div class="s3r-container" data-association="photo_uploads" data-disposition=\"attachment\" data-parent-id="#{@product.id}" data-parent-type="product"><input class="s3r-field" disposition=\"attachment\" id="file" name="file" type="file" /><table class="s3r-upload-list"></table></div>}
+      end
     end
   end
 

--- a/test/lib/s3_relay/upload_presigner_test.rb
+++ b/test/lib/s3_relay/upload_presigner_test.rb
@@ -29,7 +29,7 @@ describe S3Relay::UploadPresigner do
       data["success_action_status"].must_equal "201"
       data["acl"].must_equal "acl"
       data["endpoint"].must_equal "https://bucket.s3-region.amazonaws.com"
-      data["policy"].length.must_equal 344  # TODO: Improve this
+      data["policy"].length.must_equal 400  # TODO: Improve this
       data["signature"].length.must_equal 28  # TODO: Improve this
       data["uuid"].must_equal uuid
     end


### PR DESCRIPTION
* Sets the Content-Disposision on uploaded files to inline, with the option at the helper level to change it to attachment.
* Enables libraries like CarrierWave to pull the filename, also now stored in the Content-Disposition, to set the filename without encoding garbage.